### PR TITLE
Add token instructions + support for GITHUB_PAT and GITHUB_TOKEN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Version: 0.1.0
 Authors@R: c(person("Maëlle", "Salmon", email = "maelle.salmon@yahoo.se", role = c("aut", "cre")),
              person("Scott", "Chamberlain", role = c("aut")),
              person("rOpenSci", role = c("fnd")),
-             person("Locke Data", role = c("fnd")))
+             person("Locke Data", role = c("fnd")),
+             person("Irene", "Steves", role = c("ctb")))
 Description: Uses the ghql package and jqr to get some common data from Github V4 API.
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,24 +17,32 @@ iterate <- function(query) {
   return(out)
 }
 
+#check for token; some calls work only with specific scopes
+get_token <- function() {
+  token <- Sys.getenv("GITHUB_GRAPHQL_TOKEN")
+  if(token == ""){
+    token <- Sys.getenv("GITHUB_TOKEN", Sys.getenv("GITHUB_PAT"))
+  }
+  if(token == ""){
+    stop("Please set your GITHUB_GRAPHQL_TOKEN environment variable.")
+  }
+  return(token)
+}
+
 # function for creating the client
 # it first checks whether there's a token
 # and then only creates the client if it doesn't already exist
 create_client <- function(){
-  token <- Sys.getenv("GITHUB_GRAPHQL_TOKEN")
-  if(token == ""){
-    stop("Please set your GITHUB_GRAPHQL_TOKEN environment variable.")
-  }else{
-    if(!exists("ghql_gh_cli")){
-      ghql_gh_cli <- ghql::GraphqlClient$new(
-        url = "https://api.github.com/graphql",
-        headers = httr::add_headers(Authorization = paste0("Bearer ", token))
-      )
-      ghql_gh_cli$load_schema()
-      ghql_gh_cli <<- ghql_gh_cli
+  token <- get_token()
 
-    }
-    return(ghql_gh_cli)
+  if(!exists("ghql_gh_cli")){
+    ghql_gh_cli <- ghql::GraphqlClient$new(
+      url = "https://api.github.com/graphql",
+      headers = httr::add_headers(Authorization = paste0("Bearer ", token))
+    )
+    ghql_gh_cli$load_schema()
+    ghql_gh_cli <<- ghql_gh_cli
+
   }
-
+  return(ghql_gh_cli)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,6 +10,10 @@ iterate <- function(query) {
     qry <- ghql::Query$new()
     qry$query('foobar', sprintf(query, last_cursor))
     res <- create_client()$exec(qry$queries$foobar)
+    if(stringr::str_detect(res, "\\{\"data\":null,\"errors\"")) {
+      res_json <- jsonlite::fromJSON(res)
+      stop(res_json$errors$message)
+    }
     last_cursor <- jqr::jq(res, "[..|.cursor?|select(.!=null)][-1]")
     hasNextPage <- as.logical(jqr::jq(res, "..|.hasNextPage?|select(.!=null)"))
     out <- paste0(out, res)

--- a/README.Rmd
+++ b/README.Rmd
@@ -33,6 +33,17 @@ You can install ghrecipes from GitHub with:
 devtools::install_github("ropenscilabs/ghrecipes")
 ```
 
+## Tokens
+
+To access GitHub, `ghrecipes` looks for tokens stored in the system environment in the following order of precedence:
+
+1. GITHUB_GRAPHQL_TOKEN
+2. GITHUB_TOKEN
+3. GITHUB_PAT
+
+Most functions require only the `repo` scope. However, `get_teams()` requires either `read:org` or `read:discussion` scopes, and `get_collaborators()` requires push access to the repository of interest.
+
+For step-by-step guidance on getting and storing a GitHub token, refer to the [instructions](https://usethis.r-lib.org/articles/articles/usethis-setup.html#get-and-store-a-github-personal-access-token) in the `usethis` package.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ You can install ghrecipes from GitHub with:
 devtools::install_github("ropenscilabs/ghrecipes")
 ```
 
+## Tokens
+
+To access GitHub, `ghrecipes` looks for tokens stored in the system
+environment in the following order of precedence:
+
+1.  GITHUB\_GRAPHQL\_TOKEN
+2.  GITHUB\_TOKEN
+3.  GITHUB\_PAT
+
+Most functions require only the `repo` scope. However, `get_teams()`
+requires either `read:org` or `read:discussion` scopes, and
+`get_collaborators()` requires push access to the repository of
+interest.
+
+For step-by-step guidance on getting and storing a GitHub token, refer
+to the
+[instructions](https://usethis.r-lib.org/articles/articles/usethis-setup.html#get-and-store-a-github-personal-access-token)
+in the `usethis` package.
+
 ## Examples
 
 Don’t miss conversations by your favorite developers or comments by your
@@ -48,18 +67,18 @@ convos <- ghrecipes::spy("lintr-bot", type = "PullRequest")
 knitr::kable(convos[1:10,])
 ```
 
-| owner             | repo            | title                                                     | created\_at         | state  | author       | url                                                                                                                               | no\_comments |   id |
-| :---------------- | :-------------- | :-------------------------------------------------------- | :------------------ | :----- | :----------- | :-------------------------------------------------------------------------------------------------------------------------------- | -----------: | ---: |
-| hbc               | bcbioRNASeq     | v0.2.3                                                    | 2018-05-04 02:43:07 | OPEN   | mjsteinbaugh | <a href='https://github.com/hbc/bcbioRNASeq/pull/96'>https://github.com/hbc/bcbioRNASeq/pull/96</a>                               |            5 |   96 |
-| hbc               | bcbioBase       | v0.2.10                                                   | 2018-05-03 14:33:45 | MERGED | mjsteinbaugh | <a href='https://github.com/hbc/bcbioBase/pull/34'>https://github.com/hbc/bcbioBase/pull/34</a>                                   |            3 |   34 |
-| hbc               | bcbioSingleCell | v0.1.5                                                    | 2018-05-02 16:26:31 | MERGED | mjsteinbaugh | <a href='https://github.com/hbc/bcbioSingleCell/pull/51'>https://github.com/hbc/bcbioSingleCell/pull/51</a>                       |            5 |   51 |
-| PredictiveEcology | SpaDES.tools    | Fixed issue with empty CHECKSUMS.txt                      | 2018-04-27 06:43:49 | MERGED | CeresBarros  | <a href='https://github.com/PredictiveEcology/SpaDES.tools/pull/28'>https://github.com/PredictiveEcology/SpaDES.tools/pull/28</a> |            2 |   28 |
-| Azure             | doAzureParallel | Enable AAD and VNet Support                               | 2018-04-17 18:50:14 | MERGED | brnleehng    | <a href='https://github.com/Azure/doAzureParallel/pull/252'>https://github.com/Azure/doAzureParallel/pull/252</a>                 |            3 |  252 |
-| ropensci          | drake           | add arg ‘sanitize\_targets’ to ‘build\_drake\_graph()’    | 2018-03-24 22:03:28 | CLOSED | ChrisMuir    | <a href='https://github.com/ropensci/drake/pull/342'>https://github.com/ropensci/drake/pull/342</a>                               |            6 |  342 |
-| mlr-org           | mlr             | Oneclass r learner h2o - for INTERNAL REVIEW - DONT MERGE | 2017-05-24 14:47:05 | OPEN   | berndbischl  | <a href='https://github.com/mlr-org/mlr/pull/1807'>https://github.com/mlr-org/mlr/pull/1807</a>                                   |            2 | 1807 |
-| NA                | NA              | NA                                                        | NA                  | NA     | NA           | NA                                                                                                                                |           NA |   NA |
-| NA                | NA              | NA                                                        | NA                  | NA     | NA           | NA                                                                                                                                |           NA |   NA |
-| NA                | NA              | NA                                                        | NA                  | NA     | NA           | NA                                                                                                                                |           NA |   NA |
+| owner             | repo         | title                         | created\_at         | state  | author   | url                                                                                                                               | no\_comments |  id |
+| :---------------- | :----------- | :---------------------------- | :------------------ | :----- | :------- | :-------------------------------------------------------------------------------------------------------------------------------- | -----------: | --: |
+| PredictiveEcology | SpaDES.tools | move RandomFields to Suggests | 2018-09-18 23:04:49 | MERGED | achubaty | <a href='https://github.com/PredictiveEcology/SpaDES.tools/pull/50'>https://github.com/PredictiveEcology/SpaDES.tools/pull/50</a> |            1 |  50 |
+| PredictiveEcology | SpaDES.tools | rasterizeReduced uses crs     | 2018-09-04 20:40:18 | MERGED | achubaty | <a href='https://github.com/PredictiveEcology/SpaDES.tools/pull/49'>https://github.com/PredictiveEcology/SpaDES.tools/pull/49</a> |            1 |  49 |
+| bokeh             | rbokeh       | Update to 0.12.5              | 2017-06-07 20:11:51 | OPEN   | hafen    | <a href='https://github.com/bokeh/rbokeh/pull/217'>https://github.com/bokeh/rbokeh/pull/217</a>                                   |            7 | 217 |
+| NA                | NA           | NA                            | NA                  | NA     | NA       | NA                                                                                                                                |           NA |  NA |
+| NA                | NA           | NA                            | NA                  | NA     | NA       | NA                                                                                                                                |           NA |  NA |
+| NA                | NA           | NA                            | NA                  | NA     | NA       | NA                                                                                                                                |           NA |  NA |
+| NA                | NA           | NA                            | NA                  | NA     | NA       | NA                                                                                                                                |           NA |  NA |
+| NA                | NA           | NA                            | NA                  | NA     | NA       | NA                                                                                                                                |           NA |  NA |
+| NA                | NA           | NA                            | NA                  | NA     | NA       | NA                                                                                                                                |           NA |  NA |
+| NA                | NA           | NA                            | NA                  | NA     | NA       | NA                                                                                                                                |           NA |  NA |
 
 ## Use cases in the wild
 

--- a/tests/testthat/test-get_token.R
+++ b/tests/testthat/test-get_token.R
@@ -1,0 +1,34 @@
+context("test-get_token")
+
+test_that("check that correct token is retrieved", {
+  mock_sysgetenv <- function(gh_graphql, gh_token, gh_pat) {
+    function(x, unset = ""){
+      token <- switch(x,
+                      "GITHUB_GRAPHQL_TOKEN" = gh_graphql,
+                      "GITHUB_TOKEN" = gh_token,
+                      "GITHUB_PAT" = gh_pat)
+      if(token != "") return(token)
+      return(unset)
+    }
+  }
+
+  with_mock(
+    Sys.getenv = mock_sysgetenv("aa", "bb", "cc"),
+    expect_equal(get_token(), "aa")
+  )
+
+  with_mock(
+    Sys.getenv = mock_sysgetenv("", "bb", "cc"),
+    expect_equal(get_token(), "bb")
+  )
+
+  with_mock(
+    Sys.getenv = mock_sysgetenv("", "", "cc"),
+    expect_equal(get_token(), "cc")
+  )
+
+  with_mock(
+    Sys.getenv = mock_sysgetenv("", "", ""),
+    expect_error(get_token())
+  )
+})


### PR DESCRIPTION
In this PR, I made the following changes:

- added `get_tokens()` to retrieve tokens in the following order of precedence: 1. GITHUB_GRAPHQL_TOKEN 2. GITHUB_TOKEN 3. GITHUB_PAT
- changed `iterate()` to stop and return error message given in responses
- added a note about tokens in the README

It's probably a good idea to add a test, but I'm not sure what the best way is of doing that.

Relevant issues/code that came up in my discussion with @maelle : 
https://github.com/ropenscilabs/ghrecipes/issues/6
https://github.com/ropensci/ghql/issues/11
https://github.com/r-lib/whoami/blob/master/R/whoami.R#L279
https://github.com/r-lib/gh/blob/bed43d354789d2e4dde75db0327da1d46358f953/R/gh_request.R#L143
