### PR TITLE
construct the header as crul expects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,6 @@ Imports:
     jsonlite,
     yaml,
     dplyr,
-    httr,
     purrr,
     glue,
     rlang,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Encoding: UTF-8
 LazyData: true
 Imports: 
     jqr,
-    ghql,
+    ghql (>= 0.1.0),
     stringr,
     tibble,
     anytime,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -46,7 +46,7 @@ create_client <- function(){
   if(!exists("ghql_gh_cli")){
     ghql_gh_cli <- ghql::GraphqlClient$new(
       url = "https://api.github.com/graphql",
-      headers = httr::add_headers(Authorization = paste0("Bearer ", token))
+      headers = list(Authorization = paste0("Bearer ", token))
     )
     ghql_gh_cli$load_schema()
     ghql_gh_cli <<- ghql_gh_cli


### PR DESCRIPTION
ghql switched to crul instead of httr in
https://github.com/ropensci/ghql/issues/10

This small change will correct the failure and close #30 

The error has not been seen before because tests are not ran frequently. If you reran previous tests with the new ghql version, they failed. 
